### PR TITLE
Add Jaeger traces scenario with microsim

### DIFF
--- a/scenarios/traces/jaeger-via-microsim/Makefile
+++ b/scenarios/traces/jaeger-via-microsim/Makefile
@@ -1,0 +1,38 @@
+NS="microsim"
+
+.PHONY: all
+all: install
+
+.PHONY: helm-deps
+helm-deps:
+	helm dependency update chart/
+
+
+.PHONY: install upgrade deploy
+deploy: install
+upgrade: install
+install: helm-deps
+	helm upgrade --install microsim chart \
+		--wait \
+		--timeout 15m \
+		--namespace "$(NS)" \
+		--create-namespace \
+		-f values.yaml
+
+.PHONY: uninstall
+uninstall:
+	helm uninstall microsim --namespace "$(NS)"
+
+jaeger-ui:
+	open http://localhost:16686
+	kubectl port-forward -n "$(NS)" svc/microsim-jaeger-query 16686:80
+
+otel:
+	helm upgrade --install microsim chart \
+		--wait \
+		--timeout 15m \
+		--namespace "$(NS)" \
+		--create-namespace \
+		--set microsimCollector='http://tobs-opentelemetry-collector.bench.svc:14268/api/traces' \
+		--set jaeger.collector.enabled=false \
+		-f values.yaml

--- a/scenarios/traces/jaeger-via-microsim/README.md
+++ b/scenarios/traces/jaeger-via-microsim/README.md
@@ -1,0 +1,37 @@
+# Jaeger with microsim
+
+This benchmarking scenario is meant to test the performance of Promscale
+ingestion of Jaeger traces using Microsim and queries through the Jaeger UI. It
+deploys microsim, Jaeger collector and Jaeger query.
+
+## How to run
+
+To start the load generator execute the following command:
+
+```shell 
+make 
+```
+
+This will create a namespace `microsim` and deploy the 3 resources.
+
+If you want to deploy the scanrio using the OTEL collector instead of the 
+Jaeger collector, run:
+
+```shell
+make otel
+```
+
+To access the Jaeger UI on localhost:16686 run:
+
+```shell
+make jaeger-ui
+```
+
+## Configuration
+
+The load generator can be configured by changing options in `values.yaml`. To 
+apply new options run:
+
+```shell 
+make
+```

--- a/scenarios/traces/jaeger-via-microsim/chart/Chart.yaml
+++ b/scenarios/traces/jaeger-via-microsim/chart/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: microsim
+version: 0.0.1
+dependencies:
+  - name: jaeger
+    repository: https://jaegertracing.github.io/helm-charts
+    version: ">=0.62.1"

--- a/scenarios/traces/jaeger-via-microsim/chart/templates/microsim.yaml
+++ b/scenarios/traces/jaeger-via-microsim/chart/templates/microsim.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-microsim
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: microsim
+spec:
+  replicas: {{ .Values.microsimReplicas }}
+  selector:
+    matchLabels:
+      app: microsim
+  template:
+    metadata:
+      labels:
+        app: microsim
+    spec:
+      containers:
+      - name: microsim
+        image: yurishkuro/microsim
+        args:
+          - "-j"
+          - "{{ .Values.microsimCollector }}"
+          - "-w"
+          - "{{ .Values.microsimWorkers }}"
+          - "-d"
+          - "{{ .Values.microsimTestDuration }}"
+          - "-s"
+          - "{{ .Values.microsimSleepDuration }}"

--- a/scenarios/traces/jaeger-via-microsim/chart/values.yaml
+++ b/scenarios/traces/jaeger-via-microsim/chart/values.yaml
@@ -1,0 +1,32 @@
+microsimReplicas: 1
+microsimWorkers: 3
+microsimTestDuration: "10m"
+microsimSleepDuration: "100ms"
+microsimCollector: "http://microsim-jaeger-collector.microsim.svc:14268/api/traces"
+# To use the OTEL collector you can use `make otel` or set the
+# microsimCollector to:
+# microsimCollector: "http://microsim-opentelemetry-collector.microsim.svc:14268/api/traces"
+
+jaeger:
+  tag: "1.38.1"
+  provisionDataStore:
+    cassandra: false
+  storage:
+    type: grpc-plugin
+    grpcPlugin:
+      extraEnv:
+        - name: GRPC_STORAGE_SERVER
+          value: "tobs-promscale.bench.svc:9202"
+  agent:
+    enabled: false
+  collector:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: tobs
+  agentSidecar:
+    enabled: false
+  query:
+    agentSidecar:
+      enabled: false


### PR DESCRIPTION
This scenario installs microsim as a load generator for traces, the Jaeger collector and Jaeger UI for ingest and query.

It can also be set up to use the OTEL collector instead of the Jaeger collector. 