### PR TITLE
stack: remove stale property

### DIFF
--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -1,7 +1,5 @@
 timescaledb-single:
   enabled: true
-  loadBalancer:
-    enabled: false
   replicaCount: 1
   backup:
     enabled: false


### PR DESCRIPTION
TimescaleDB-single helm chart removed a `loadBalancer` property in [version 0.20.0](https://github.com/timescale/helm-charts/releases/tag/timescaledb-single-0.20.0). We need to update this repository to prevent issues with schema validation.
