### PR TITLE
allow access to "Explore" tab in grafana

### DIFF
--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -107,6 +107,7 @@ kube-prometheus-stack:
     enabled: true
     env:
       GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Editor"
     envValueFrom:
       GRAFANA_PASSWORD:
     prometheus:


### PR DESCRIPTION
Grafana shipped with `make stack` is configured to grant anonymous access. However, defaults for anonymous access in grafana grant only "Viewer" role which doesn't allow to use "Explore" tab. This PR is reconfiguring anonymous access to elevate used role to "Editor" and allow access to "Explore" tab.