### PR TITLE
stack: disable admission webhooks for prometheus-operator as they are unnecessary here

### DIFF
--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -70,6 +70,9 @@ kube-prometheus-stack:
     enabled: false
   alertmanager:
     enabled: false
+  prometheusOperator:
+    admissionWebhooks:
+      enabled: false
   # This prometheus is monitoring the cluster. Do not use it for load generation.
   prometheus:
     prometheusSpec:


### PR DESCRIPTION
Admission webhooks for prometheus-operator are supposed to prevent from injecting malformed PrometheusRule object. However since this environment is not dynamic and it is not using custom PrometheusRules, there is no point in having this webhook enabled.

This should prevent issues like:
```
Error: UPGRADE FAILED: failed to create resource: Internal error occurred: failed calling webhook "prometheusrulemutate.monitoring.coreos.com": failed to call webhook: Post "[https://tobs-kube-prometheus-stack-operator.bench.svc:443/admission-prometheusrules/validate?timeout=10s](https://tobs-kube-prometheus-stack-operator.bench.svc/admission-prometheusrules/validate?timeout=10s)": x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "nil1")
make: *** [install] Error 1
```
