### PR TITLE
Disable Prom Operator TLS as it is no longer required with webhooks disabled

### DIFF
--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -79,6 +79,8 @@ kube-prometheus-stack:
   alertmanager:
     enabled: false
   prometheusOperator:
+    tls:
+      enabled: false
     admissionWebhooks:
       enabled: false
   # This prometheus is monitoring the cluster. Do not use it for load generation.


### PR DESCRIPTION
There is a logical bug in kube-prometheus-stack helm chart (prometheus-community/helm-charts#1438) that TLS relies on self-signed certificates but these certificates are created by a admission-webhooks job. If we disable the webhooks then the secret with the certs is never created and Kubernetes fails to start the pod with the error message.

```
MountVolume.SetUp failed for volume "tls-secret" : secret "prometheus-kube-prometheus-admission" not found
```
 
Until this is fixed in upstream we can just disable TLS as it is only mandatory for admissionWebhooks and we have them disabled in our stack.