### PR TITLE
scenarios/metrics: add scaffolding for query-promql scenario

### DIFF
--- a/scenarios/metrics/query-promql/Makefile
+++ b/scenarios/metrics/query-promql/Makefile
@@ -1,0 +1,20 @@
+NS="metrics-query-promql"
+
+.PHONY: all
+all: install
+
+.PHONY: install upgrade deploy
+deploy: install
+upgrade: install
+install:
+	helm upgrade --install query-promql chart \
+		--wait \
+		--timeout 15m \
+		--namespace "$(NS)" \
+		--create-namespace \
+		-f values.yaml \
+		-f values-overrides.yaml
+
+.PHONY: uninstall
+uninstall:
+	helm uninstall query-promql --namespace "$(NS)"

--- a/scenarios/metrics/query-promql/README.md
+++ b/scenarios/metrics/query-promql/README.md
@@ -1,11 +1,31 @@
 # Query data using PromQL
 
-TBD
+This benchmarking scenario is meant to test the performance of Promscale metrics query when using Prometheus as a metrics source. It deploys a single instance of promethues and gathers data from prometheus and node_exporter pods running in the cluster.
+
+Prometheus is deployed using kubernetes Custom Resource and it is managed by prometheus-operator shipped with tobs.
+
+_Warning: This scenario is ingesting data from node_exporters running in the cluster. As such ingested data volume depends on number of nodes. This in turn can have impact on query capabilities._
 
 ## How to run
 
-TBD
+To start the load generator execute the following command:
+
+```shell
+make
+```
+
+This will create a namespace `metrics-ingest-direct` and deploy avalanche to it. Alternativelly, you can put this load generator in a different namespace, for example `benchmark`, by running:
+
+```shell
+
+```shell
+NS="benchmark" make
+```
 
 ## Configuration
 
-TBD
+Prometheus ingesting data and query load generator can be configured by changing options in `values.yaml`. To apply new options run:
+
+```shell
+make upgrade
+```

--- a/scenarios/metrics/query-promql/chart/Chart.yaml
+++ b/scenarios/metrics/query-promql/chart/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: query-promql
+version: 0.0.1

--- a/scenarios/metrics/query-promql/chart/templates/clusterRole.yaml
+++ b/scenarios/metrics/query-promql/chart/templates/clusterRole.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-prometheus-role
+  labels:
+    app.kubernetes.io/part-of: query-promql
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch

--- a/scenarios/metrics/query-promql/chart/templates/clusterRoleBinding.yaml
+++ b/scenarios/metrics/query-promql/chart/templates/clusterRoleBinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-prometheus-role-binding
+  labels:
+    app.kubernetes.io/part-of: query-promql
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-prometheus-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-prometheus-sa
+  namespace: {{ .Release.Namespace }}

--- a/scenarios/metrics/query-promql/chart/templates/prometheus.yaml
+++ b/scenarios/metrics/query-promql/chart/templates/prometheus.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: query-promql
+spec:
+  version: {{ .Values.prometheus.version }}
+  image: "quay.io/prometheus/prometheus:{{ .Values.prometheus.version }}"
+  replicas: 1
+  remoteWrite:
+  {{ .Values.prometheus.remoteWrite | toYaml | nindent 4 }}
+  resources:
+  {{ .Values.prometheus.resources | toYaml | nindent 4 }}
+  retention: 2h
+  serviceMonitorSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: query-promql
+      tobs/excluded: "true"
+  serviceMonitorSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: query-promql
+      tobs/excluded: "true"
+  podMetadata:
+    labels:
+      app.kubernetes.io/part-of: query-promql
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - timescaledb
+          topologyKey: kubernetes.io/hostname
+        weight: 100
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - connector
+          topologyKey: kubernetes.io/hostname
+        weight: 50
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - prometheus
+          topologyKey: kubernetes.io/hostname
+        weight: 50
+  serviceAccountName: {{ .Release.Name }}-prometheus-sa

--- a/scenarios/metrics/query-promql/chart/templates/service.yaml
+++ b/scenarios/metrics/query-promql/chart/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: query-promql
+spec:
+  ports:
+  - name: web
+    port: 9090
+    targetPort: web
+  - name: reloader-web
+    port: 8080
+    targetPort: reloader-web
+  selector:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: query-promql
+  sessionAffinity: ClientIP

--- a/scenarios/metrics/query-promql/chart/templates/serviceAccount.yaml
+++ b/scenarios/metrics/query-promql/chart/templates/serviceAccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-prometheus-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: query-promql

--- a/scenarios/metrics/query-promql/chart/templates/serviceMonitor-nodeExporter.yaml
+++ b/scenarios/metrics/query-promql/chart/templates/serviceMonitor-nodeExporter.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-node-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/part-of: query-promql
+    tobs/excluded: "true"
+spec:
+  jobLabel: jobLabel
+  endpoints:
+  - interval: 30s
+    scheme: http
+    port: http-metrics
+  namespaceSelector:
+    matchNames:
+    - bench
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: tobs
+      app.kubernetes.io/name: prometheus-node-exporter

--- a/scenarios/metrics/query-promql/chart/templates/serviceMonitor-prometheus.yaml
+++ b/scenarios/metrics/query-promql/chart/templates/serviceMonitor-prometheus.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: query-promql
+    tobs/excluded: "true"
+spec:
+  endpoints:
+  - interval: 30s
+    port: web
+  - interval: 30s
+    port: reloader-web
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+    - bench
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus

--- a/scenarios/metrics/query-promql/values.yaml
+++ b/scenarios/metrics/query-promql/values.yaml
@@ -1,0 +1,22 @@
+prometheus:
+  version: v2.39.1
+  # Configuration options in https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RemoteWriteSpec
+  remoteWrite:
+  - url: http://tobs-promscale.bench.svc:9201/write
+    remoteTimeout: 100s
+    # Configuration options in https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#queueconfig
+    queueConfig:
+      capacity: 100000
+      minShards: 20
+      maxShards: 20
+      maxSamplesPerSend: 10000
+      batchSendDeadline: 30s
+      minBackoff: 100ms
+      maxBackoff: 10s
+  resources:
+    requests:
+      cpu: 40m
+      memory: 400Mi
+
+# TODO: add querier configuation options
+# querier:


### PR DESCRIPTION
This PR is adding base for query-promql scenario. It contains of prometheus server gathering data from all prometheus servers in a cluster and from all node_exporters. Prometheus is then sending this data to promscale server located in `bench` namespace. Later on we can extend amount of data gathered by adding more ServiceMonitors or PodMonitors labeled with the following labels:
```yaml
    app.kubernetes.io/part-of: query-promql
    tobs/excluded: "true"
```

This PR is lacking proper querier (load generator) which needs to be added in subsequent PR.

Signed-off-by: Paweł Krupa (paulfantom) <pawel@krupa.net.pl>