### PR TITLE
add default tolerations and nodeAffinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ endpoint in Promscale.
       - [Amazon EKS](#amazon-eks)
     - [Stack installation](#stack-installation)
     - [Updating](#updating)
+    - [Pod placement](#pod-placement)
   - [Benchmark scenarios](#benchmark-scenarios)
     - [Available scenarios](#available-scenarios)
     - [Run a scenario](#run-a-scenario)
@@ -104,6 +105,10 @@ can edit the `stack/values.yaml` file and run:
 ```
 make stack
 ```
+
+### Pod placement
+
+To ensure that pods are placed on nodes we want them to be on we are offering methods described in [docs/pod-placement.md](docs/pod-placement.md).
 
 ## Benchmark scenarios
 

--- a/docs/pod-placement.md
+++ b/docs/pod-placement.md
@@ -1,0 +1,94 @@
+# Pod placement
+
+Document describes used methods to place pods on specific nodes.
+
+## Quick start
+
+To quickly place pods on specific nodes you can use the following command:
+
+```shell
+# Place database on a separate, dedicated node
+DB_NODE=<NODE_NAME>
+kubectl taint nodes "${DB_NODE}" database=true:NoSchedule
+kubectl label node "${DB_NODE}" topology.kubernetes.io/zone=database
+
+# Place promscale-connector on a separate, dedicated node
+CONNECTOR_NODE=<NODE_NAME>
+kubectl taint nodes "${CONNECTOR_NODE}" connector=true:NoSchedule
+kubectl label node "${CONNECTOR_NODE}" topology.kubernetes.io/zone=connector
+```
+
+This will taint nodes and apply labels to them. Tolerations, anti-affinity, and node affinity settings are already applied to the stack.
+
+## Pod anti-affinity
+
+Stack is by defualt configured to use anti-affinity to repel pods from other pods when choosing node to place them on. Configuration is done in `stack/values.yaml` file and it is supposed to repulse prometheus, promcale-connector, and databse pods from being placed on the same node. This is done to avoid the situation when all pods are placed on the same node and the node is overloaded. This is only a soft constraint and it is possible that all pods are placed on the same node.
+
+We are using the following configuration, example for promscale-connector:
+
+```yaml
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - timescaledb
+          topologyKey: "kubernetes.io/hostname"
+```
+
+## Node affinity
+
+Stack is by defualt configured to use node affinity to attract pods to specific nodes. Configuration is done in `stack/values.yaml` file and it is supposed to attract pods to specific node, primarily tainted ones. This is only a soft constraint and it is possible that all pods are placed on the same node.
+
+We are using the following configuration, example for promscale-connector:
+
+```yaml
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            - connector
+```
+
+### Label nodes
+
+To use node affinity, nodes need to have proper labels on them. This can be done by using `kubectl label` command. Example:
+
+```shell
+NODE=<NODE_NAME>
+
+kubectl label node "${NODE}" topology.kubernetes.io/zone=connector
+```
+
+Ideally this is done in conjunction with tainting node as described in [taints](#taints) section.
+
+## Taints and Tolerations
+
+To make sure that nodes "accept" only specific pods we are using taints and tolerations. Taints are set on nodes and tolerations are set on pods. Default tolerations are set in `stack/values.yaml` file.
+
+### Taints
+
+Taints need to be applied manually on nodes. To apply taints on nodes run the following command:
+
+```shell
+NODE=<NODE_NAME>
+
+# Taint node for database
+kubectl taint nodes "${NODE}" database=true:NoSchedule
+```
+
+### Tolerations
+
+By default database and connector pods are configured to tolerate specific taints.
+
+Connector pods by default tolerate `connector=true:NoSchedule` taint. This is done to make sure that connector pods are placed on nodes with database pods.
+
+Database pods by default tolerate `database=true:NoSchedule` taint. This is done to make sure that database pods are placed on nodes with connector pods.

--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -16,6 +16,10 @@ timescaledb-single:
     requests:
       cpu: 100m
       memory: 2Gi
+  tolerations:
+  - key: "database"
+    operator: "Exists"
+    effect: "NoSchedule"
   affinityTemplate: |
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -28,6 +32,15 @@ timescaledb-single:
               values:
               - connector
           topologyKey: "kubernetes.io/hostname"
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            - database
 
 promscale:
   enabled: true
@@ -51,6 +64,10 @@ promscale:
     startup.dataset.config: |
       metrics:
         default_chunk_interval: 1h
+  tolerations:
+  - key: "connector"
+    operator: "Exists"
+    effect: "NoSchedule"
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -63,6 +80,15 @@ promscale:
               values:
               - timescaledb
           topologyKey: "kubernetes.io/hostname"
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            - connector
 
 kube-prometheus-stack:
   enabled: true


### PR DESCRIPTION
We can add default tolerations to specific pods to ensure they are allowed to be placed on specific nodes. This in conjunction with taints should give us a flexible configuration for benchmarking.