### PR TITLE
Fix values-overrides default

### DIFF
--- a/stack/values-overrides.yaml
+++ b/stack/values-overrides.yaml
@@ -12,7 +12,7 @@ timescaledb-single:
     bootstrap:
       dcs:
         postgresql:
-          parameters:
+          parameters: {}
             # track_io_timing: on
 
 # Configuration options are documented at:


### PR DESCRIPTION
Change the default parameters from nil to an empty dictionary. Nil clears out the field, overriding any changes from values.yaml