### PR TITLE
Reduce avalanche scraping prometheus retention to 2h

### DIFF
--- a/scenarios/metrics/ingest-with-prometheus/values.yaml
+++ b/scenarios/metrics/ingest-with-prometheus/values.yaml
@@ -13,7 +13,7 @@ prometheus:
       batchSendDeadline: 30s
       minBackoff: 100ms
       maxBackoff: 10s
-  retention: 1d
+  retention: 2h
   resources:
     requests:
       cpu: 40m


### PR DESCRIPTION
Having 1d retention causes higher memory usage of avalanche scraping prometheus.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>