### PR TITLE
stack: use affinity field for tsdb config

### DIFF
--- a/stack/values.yaml
+++ b/stack/values.yaml
@@ -20,7 +20,7 @@ timescaledb-single:
   - key: "database"
     operator: "Exists"
     effect: "NoSchedule"
-  affinityTemplate: |
+  affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100


### PR DESCRIPTION
Migrating stack to use `affinity` field instead of `affinityTemplate` for TimescaleDB chart.

Blocked on https://github.com/timescale/helm-charts/pull/529

Required by https://github.com/timescale/helm-charts/pull/528