### PR TITLE
Remove `--node-type` from scaling instructions

### DIFF
--- a/docs/eks.md
+++ b/docs/eks.md
@@ -110,7 +110,7 @@ can do so by running the following:
 2. Change the nodegroup:
 
     ```shell
-    eksctl scale nodegroup --cluster "$NAME" --region "$REGION" --node-type m5.xlarge --nodes 5 --nodes-min 1 --nodes-max 5 --name <nodegroup-name>
+    eksctl scale nodegroup --cluster "$NAME" --region "$REGION" --nodes 5 --nodes-min 1 --nodes-max 5 --name <nodegroup-name>
     ```
 
 3. Wait until the nodes are up and running:


### PR DESCRIPTION
Scaling a node in EKS does not support `--node-type`. The scaling happens within the same node-type that was used at the start of creating the node-group.

Signed-off-by: Harkishen Singh <harkishensingh@hotmail.com>